### PR TITLE
Ec order show view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -328,7 +328,7 @@ nav {
 	background-color: #eeeeee;
 	display: inline-block;
 	margin: 20px;
-	margin-top: 100px;
+	margin-top: 20px;
 }
 
 .ec_shipping_address_create_button{

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,9 +11,10 @@ class ApplicationController < ActionController::Base
     end
 
     def after_sign_out_path_for(resource)
-      if resource == :admin
+      case resource
+      when :owner
         new_owner_session_path
-      else
+      when :customer
         root_path
       end
     end

--- a/app/controllers/customers/customers_controller.rb
+++ b/app/controllers/customers/customers_controller.rb
@@ -12,7 +12,7 @@ class Customers::CustomersController < ApplicationController
     @customer.unavailable!
     if @customer.status == "unavailable"
       flash[:success] = "退会処理が完了しました。ご利用ありがとうございました。"
-      redirect_to customers_items_path
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/customers/shipping_addresses_controller.rb
+++ b/app/controllers/customers/shipping_addresses_controller.rb
@@ -3,20 +3,26 @@ class Customers::ShippingAddressesController < ApplicationController
 
 	def index
 		@shipping_address = ShippingAddress.new
-		@shipping_addresses = ShippingAddress.all
+		@shipping_addresses = ShippingAddress.where(customer_id: current_customer.id)
 	end
 
 	def create
-		@shipping_address = ShippingAddress.new(shipping_address_params)
-		@shipping_address.customer_id = current_customer.id
+		# Customer、Shipping_addressそれぞれのアドレス情報を検索して、存在しない場合のみShipping_addressに登録
+		if (current_customer.postal_code != params[:shipping_address][:shipping_postal_code] && current_customer.address != params[:shipping_address][:shipping_address] && current_customer.last_name + current_customer.first_name != params[:shipping_address][:address_name]) && (current_customer.shipping_addresses.where(shipping_postal_code: params[:shipping_address][:shipping_postal_code], shipping_address: params[:shipping_address][:shipping_address], address_name: params[:shipping_address][:address_name]).blank?)
 
-		if @shipping_address.save
-			redirect_to customer_shipping_addresses_path
-      flash[:success] = "配送先の作成に成功しました！"
+			@shipping_address = ShippingAddress.new(shipping_address_params)
+			@shipping_address.customer_id = current_customer.id
+			if @shipping_address.save
+				flash[:success] = "配送先の作成に成功しました！"
+			else
+				@shipping_addresses = ShippingAddress.where(customer_id: current_customer.id)
+				render "index" and return
+			end
 		else
-      @shipping_addresses = ShippingAddress.all
-			render "index"
+			flash[:notice] = "既に登録されている配送先、もしくはご自身の住所と同一です。ご自身の住所の変更はマイページから行ってください。"
 		end
+		@shipping_address = ShippingAddress.new
+		redirect_to customer_shipping_addresses_path(current_customer.id)
 	end
 
 	def destroy

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,4 @@
 class HomeController < ApplicationController
-	before_action :authenticate_customer!
-
   def top
     @genres = Genre.where(status: true)
     @items = Item.find(1, 2, 3, 4)

--- a/app/views/customers/cart_items/index.html.erb
+++ b/app/views/customers/cart_items/index.html.erb
@@ -44,7 +44,7 @@
     </table>
     <div class="shopping_btn">
       <div class="shopping_continue_btn">
-        <%= link_to  "買い物を続ける", customers_items_path %>
+        <%= link_to  "買い物を続ける", root_path %>
       </div>
 
       <dl class="cart_total_price">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,9 @@
       <header>
         <div class="col-xs-1"></div>
         <div class="col-xs-3">
-          <%= image_tag "logo.png", class: "img-fluid" %>
+          <%= link_to root_path do %>
+            <%= image_tag "logo.png", class: "img-fluid" %>
+          <% end %>
         </div>
 
         <nav class="col-xs-8">


### PR DESCRIPTION
### EC側配送先一覧ページを修正しました。
- ログイン中のカスタマーの情報のみ一覧表示されるように修正しました。
- Customerのアドレスと、ShippingAddressテーブルを検索したのち、存在しない配送先情報のみを登録するように修正しました。
- 上記の場合、「既に登録されている配送先、もしくはご自身の住所と同一です。ご自身の住所の変更はマイページから行ってください。」というメッセージが出力されるようにしています。
### ルートパスとアイテム一覧ページのパスを混同していたため修正しました。
