### PR TITLE
Fix order index source

### DIFF
--- a/app/controllers/owners/items_controller.rb
+++ b/app/controllers/owners/items_controller.rb
@@ -1,10 +1,9 @@
 class Owners::ItemsController < ApplicationController
- before_action :authenticate_owner! 一時的に無効化
+  before_action :authenticate_owner! 一時的に無効化
 
 def new
   @item = Item.new
   @genres = Genre.where(status: true)
-
 end
 
 def create

--- a/app/controllers/owners/orders_controller.rb
+++ b/app/controllers/owners/orders_controller.rb
@@ -2,8 +2,17 @@ class Owners::OrdersController < ApplicationController
   before_action :authenticate_owner!
 
 	def index
-		@order = Order.all
-		@orders = Order.all.page(params[:page]).per(10)
+		case params[:order_index_source]
+			when "from_header"
+				@orders = Order.all.page(params[:page]).per(10)
+				@order_index_source = params[:order_index_source]
+			when "from_top"
+				@orders = Order.where(created_at: Time.zone.now.all_day).page(params[:page]).per(10)
+				@order_index_source = params[:order_index_source]
+			when "from_show_owner"
+				@orders = Order.where(customer_id: params[:customer_source]).all.page(params[:page]).per(10)
+				@order_index_source = params[:order_index_source]
+		end
 	end
 
 	def show

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -1,13 +1,9 @@
 class OwnersController < ApplicationController
- 
 
- 	def top
-		@orders = Order.all
-		if @orders.where([:created_at].to_s.match(/#{Date.today.to_s}.+/)).present?
-			@data = @orders.where([:created_at].to_s.match(/#{Date.today.to_s}.+/)).count
-		else
-			@data = "注文なし！"
+	def top
+		if Order.where(created_at: Time.zone.now.all_day).present?
+			@data = Order.where(created_at: Time.zone.now.all_day).count
 		end
- 	end
+	end
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
             <% elsif owner_signed_in? %>
               <li><%= link_to "商品一覧", owners_items_index_owner_path, class: "btn btn-default header_list_item" %></li>
               <li><%= link_to "会員一覧", owners_customers_path, class: "btn btn-default header_list_item" %></li>
-              <li><%= link_to "注文履歴一覧", owners_orders_path, class: "btn btn-default header_list_item" %></li>
+              <li><%= link_to "注文履歴一覧", owners_orders_path(:order_index_source => "from_header"), class: "btn btn-default header_list_item" %></li>
               <li><%= link_to "ジャンル一覧", owners_genres_path, class: "btn btn-default header_list_item" %></li>
               <li><%= link_to "ログアウト", destroy_owner_session_path, method: :delete, class: "btn btn-default header_list_item" %></li>
             <% else %>

--- a/app/views/owners/customers/show_owner.html.erb
+++ b/app/views/owners/customers/show_owner.html.erb
@@ -1,72 +1,72 @@
 <div class="container" style="margin:1vw 50px 0;">
   <div class="row">
-      <h3 class="ow_ganre_title"><%= @customer.last_name %><%= @customer.first_name %>さんの会員詳細</h3>
+		<h3 class="ow_ganre_title"><%= @customer.last_name %><%= @customer.first_name %>さんの会員詳細</h3>
   </div>
 </div>
 
 <div class="continer mt-4">
-<div class="row ml-5">
-	<table class="col-4 table table-border bg-light" style="margin-top:20px;">
-    <tr>
-		  <th>顧客ID</th>
-		   <td>
-			   <%= @customer.id %>
-		        <%if @customer.status == "available"%>
-		        <span><%= "有効会員" %></span>
-		        <% else %>
-		        <span><%= "退会済み" %></span>
-		        <% end %>
-		   </td>
-    </tr>
-    <tr>
-		  <th>氏名</th>
-		  <td>
-			  <%= @customer.last_name %>
-			  <%= @customer.first_name %>
-		  </td>
-    </tr>
-    <tr>
-		  <th>フリガナ</th>
-		  <td>
-			  <%= @customer.last_furigana %>
-			  <%= @customer.first_furigana %>
-		  </td>
-    </tr>
-    <tr>
-		  <th>郵便番号</th>
-		  <td>
-			  <%= @customer.postal_code %>
-		  </td>
-    </tr>
-    <tr>
-		  <th>住所</th>
-		  <td>
-			  <%= @customer.address %>
-		  </td>
-    </tr>
-    <tr>
-		  <th>電話番号</th>
-		  <td>
-			  <%= @customer.telephone_number %>
-		  </td>
-    </tr>
-    <tr>
-		  <th>メールアドレス</th>
-		  <td>
-			  <%= @customer.email %>
-		  </td>
-    </tr>
-  </table>
- </div>
+	<div class="row ml-5">
+		<table class="col-4 table table-border bg-light" style="margin-top:20px;">
+			<tr>
+				<th>顧客ID</th>
+				<td>
+					<%= @customer.id %>
+					<%if @customer.status == "available"%>
+						<span><%= "有効会員" %></span>
+					<% else %>
+						<span><%= "退会済み" %></span>
+					<% end %>
+				</td>
+			</tr>
+			<tr>
+				<th>氏名</th>
+				<td>
+					<%= @customer.last_name %>
+					<%= @customer.first_name %>
+				</td>
+			</tr>
+			<tr>
+				<th>フリガナ</th>
+				<td>
+					<%= @customer.last_furigana %>
+					<%= @customer.first_furigana %>
+				</td>
+			</tr>
+			<tr>
+				<th>郵便番号</th>
+				<td>
+					<%= @customer.postal_code %>
+				</td>
+			</tr>
+			<tr>
+				<th>住所</th>
+				<td>
+					<%= @customer.address %>
+				</td>
+			</tr>
+			<tr>
+				<th>電話番号</th>
+				<td>
+					<%= @customer.telephone_number %>
+				</td>
+			</tr>
+			<tr>
+				<th>メールアドレス</th>
+				<td>
+					<%= @customer.email %>
+				</td>
+			</tr>
+		</table>
+	</div>
 
   <div class="btn-toolbar">
-  <div class="btn-group">
-	<div class="col-sm-4">
-		<%= link_to "編集する", owners_edit_owner_costomer_path, class:"btn btn-primary btn-sm mt-20" %>	
-	</div>
-	<div class="col-sm-4">
-		<%= link_to "注文履歴一覧を見る", owners_orders_path, class:"btn btn-primary btn-sm mt-20" %>
-	</div>
-  </div>
+		<div class="btn-group">
+			<div class="col-sm-4">
+				<%= link_to "編集する", owners_edit_owner_costomer_path, class:"btn btn-primary btn-sm mt-20" %>	
+			</div>
+			<div class="col-sm-4">
+				<%= link_to "注文履歴一覧を見る", owners_orders_path(:order_index_source => "from_show_owner", :customer_source => @customer.id), class:"btn btn-primary btn-sm mt-20" %>
+			</div>
+		</div>
   </div>
 </div>

--- a/app/views/owners/orders/index.html.erb
+++ b/app/views/owners/orders/index.html.erb
@@ -2,32 +2,32 @@
 <div class="row" style="margin-top:30px;">
 	<div class="col-xs-10 ">
 		<table class="table table-hover table-bordered table-condensed">
-		  <thead>
-		    <tr class="active">
-		      <th>購入日時</th>
-	      	  <th>購入者</th>
-		      <th>注文個数</th>
-		      <th>注文ステータス</th>
-		    </tr>
-		  </thead>
+			<thead>
+				<tr class="active">
+					<th>購入日時</th>
+						<th>購入者</th>
+					<th>注文個数</th>
+					<th>注文ステータス</th>
+				</tr>
+			</thead>
 
-		  <tbody>
-		    <% @order.each do |order| %>
-		      <tr>
-		        <td>
-		         <%= link_to order.created_at. strftime('%Y/%m/%d/%R:%S') , owners_order_path(order) %>
-		        </td>
-		        <td>
-		        	<%= order.customer.last_name + order.customer.first_name %>
-		        </td>
-		        <td>
-		        	<% sum = 0 %>
+			<tbody>
+				<% @orders.each do |order| %>
+					<tr>
+						<td>
+							<%= link_to order.created_at. strftime('%Y/%m/%d/%R:%S') , owners_order_path(order) %>
+						</td>
+						<td>
+							<%= order.customer.last_name + order.customer.first_name %>
+						</td>
+						<td>
+							<% sum = 0 %>
 					<% order.order_items.each do |order_item| %>
 					<% sum = sum + order_item.number%>
 					<% end %>
 					<%= sum %>
-		        </td>
-    	      <td>
+						</td>
+						<td>
 							<% case order.status %>
 								<% when "waiting_payment" %>
 									入金待ち
@@ -39,11 +39,15 @@
 									発送準備中
 								<% when "shipped" %>
 									発送済み
-        			<% end %>
-						 </td>
-     	    </tr>
-		   <% end %>
-		  </tbody>
+							<% end %>
+							</td>
+					</tr>
+				<% end %>
+			</tbody>
 		</table>
+		<div class="paginate">
+			<%= paginate @orders %>
+			<%= hidden_field_tag :order_index_source => @order_index_source %>
+		</div>
 	</div>
 	</div>

--- a/app/views/owners/top.html.erb
+++ b/app/views/owners/top.html.erb
@@ -6,11 +6,15 @@
 
       <div class="ml-3">
       <h4>本日の注文
-        <%= link_to owners_orders_path do %>
-          <%= @data %>
-          <% end %> 件</h4>
+        <% if defined?@data %>
+          <%= link_to owners_orders_path(:order_index_source => "from_top") do %>
+            <%= @data %>
+          <% end %> 件
+        <% else %>
+          注文なし！
+        <% end %>
+      </h4>
       </div>
-      <%= hidden_field_tag :order_index_source, "from_top" %>
     </div>
   </div>
 </div>

--- a/app/views/owners/top.html.erb
+++ b/app/views/owners/top.html.erb
@@ -1,15 +1,15 @@
 <div class="container pb-5">
- <div class="row">
-  <div class="col-md-3">
+  <div class="row">
+    <div class="col-md-3">
 
-    <h3 class="mb-4">管理者画面</h3>
+      <h3 class="mb-4">管理者画面</h3>
 
-    <div class="ml-3">
-    <h4>本日の注文
-    	<%= link_to owners_orders_path do %>
-    	   <%= @data %>
-    	   <% end %> 件</h4>
+      <div class="ml-3">
+      <h4>本日の注文
+        <%= link_to owners_orders_path do %>
+          <%= @data %>
+          <% end %> 件</h4>
+      </div>
     </div>
   </div>
- </div>
 </div>


### PR DESCRIPTION
### Owners側の注文履歴一覧に関する以下の3点を修正した。
- 会員履歴詳細から注文履歴一覧をクリックすると、その会員の注文履歴一覧が表示されるはずが、全注文履歴が表示される。
- トップページから注文履歴一覧をクリックすると、当日の注文履歴一覧が表示されるはずが、全注文履歴が表示される。（全注文履歴の表示はヘッダからのみ）
- トップページの本日の注文件数が正しく表示されない。